### PR TITLE
Provide diff options via DiffOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,11 @@ exports.toMatchFile = function toMatchFile(content, filename, options = {}) {
   }
 
   options = {
-    expand: false,
-    contextLines: 5,
-    ...options,
+    diff: {
+      expand: false,
+      contextLines: 5,
+      ...(options.diff || {}),
+    },
   };
 
   if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(filename)) {
@@ -55,7 +57,7 @@ exports.toMatchFile = function toMatchFile(content, filename, options = {}) {
           message: () =>
             `${chalk.red('Received content')} doesn't match ${chalk.green(
               path.basename(filename)
-            )}.\n\n${diff(content, output, options)}`,
+            )}.\n\n${diff(content, output, options.diff)}`,
         };
       }
     }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const path = require('path');
 const chalk = require('chalk');
 const diff = require('jest-diff');
 
-exports.toMatchFile = function toMatchFile(content, filename) {
+exports.toMatchFile = function toMatchFile(content, filename, options = {}) {
   const { isNot, snapshotState } = this;
 
   if (!filename) {
@@ -15,6 +15,12 @@ exports.toMatchFile = function toMatchFile(content, filename) {
   if (isNot) {
     throw new Error('You cannot use `.not` with `.toMatchFile`.');
   }
+
+  options = {
+    expand: false,
+    contextLines: 5,
+    ...options,
+  };
 
   if (snapshotState._updateSnapshot === 'none' && !fs.existsSync(filename)) {
     return {
@@ -49,7 +55,7 @@ exports.toMatchFile = function toMatchFile(content, filename) {
           message: () =>
             `${chalk.red('Received content')} doesn't match ${chalk.green(
               path.basename(filename)
-            )}.\n\n${diff(content, output)}`,
+            )}.\n\n${diff(content, output, options)}`,
         };
       }
     }


### PR DESCRIPTION
`jest-diff` defaults to expanding the diffed output, which in this case means printing out the entirety of your snapshot files.

This PR exposes [`DiffOptions`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest-diff/index.d.ts#L8) from `jest-diff` as a configuration parameter, so that users can enable/disable those options. It also sets some sane defaults.