### PR TITLE
Add Typescript declaration file to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "types": "./index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
Looks like I forgot to add the declaration file to the `files` field in the `package.json` in #4, so they weren't shipped when released to npm.

v0.2.0:
```
$ list-npm-contents jest-file-snapshot
package.json
index.js
README.md
```

After this PR:
```
$ npm pack
npm notice
npm notice 📦  jest-file-snapshot@0.2.0
npm notice === Tarball Contents ===
npm notice 979B  package.json
npm notice 396B  index.d.ts
npm notice 2.2kB index.js
npm notice 1.1kB README.md
npm notice === Tarball Details ===
npm notice name:          jest-file-snapshot
npm notice version:       0.2.0
npm notice filename:      jest-file-snapshot-0.2.0.tgz
npm notice package size:  2.0 kB
npm notice unpacked size: 4.6 kB
npm notice shasum:        6880305656815d438e67876fa9f26b7ee3117f29
npm notice integrity:     sha512-a1ljwOt1WgWmU[...]7pdfKEcmFYWcA==
npm notice total files:   4
npm notice
jest-file-snapshot-0.2.0.tgz
```