### PR TITLE
Improve TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,16 +2,30 @@
 
 import { DiffOptions } from 'jest-diff';
 
-declare type FileMatcherOptions = {
-  diff: DiffOptions
+declare module 'jest-file-snapshot' {
+  export const toMatchFile: jest.CustomMatcher;
 }
 
-declare namespace jest {
-  interface Matchers<R> {
-    toMatchFile: (output: string, filename?: string, options?: FileMatcherOptions) => void
-  }
+declare interface FileMatcherOptions {
+  diff: DiffOptions;
+}
 
-  interface Expect {
-    toMatchFile: (output: string, filename?: string, options?: FileMatcherOptions) => void
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toMatchFile: (
+        output: string,
+        filename?: string,
+        options?: FileMatcherOptions
+      ) => void;
+    }
+
+    interface Expect {
+      toMatchFile: (
+        output: string,
+        filename?: string,
+        options?: FileMatcherOptions
+      ) => void;
+    }
   }
 }


### PR DESCRIPTION
See https://github.com/satya164/jest-file-snapshot/issues/2#issuecomment-474606409 for context.

I found a couple of issues in the previous TypeScript definitions:
- There was no declaration of `toMatchFile`, so it couldn't be imported (e.g. `import { toMatchFile } from "jest-file-snapshot";`)
- The augmentation of the expect() function exposed by Jest required wrapping the namespace into `declare global { ... }`

Note that the formatting change is caused by Prettier. Happy to revert this.