### PR TITLE
Set up CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+version: 2.1
+job_configuration: &job_configuration
+  docker:
+    - image: circleci/node:10-stretch
+  working_directory: ~/repo
+jobs:
+  test:
+    <<: *job_configuration
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v3-dependencies-{{ checksum "package.json" }}
+            - v3-dependencies-
+      - run: yarn install --frozen-lockfile
+      - save_cache:
+          paths:
+            - node_modules
+          key: v3-dependencies-{{ checksum "package.json" }}
+      - run:
+          name: Run tests
+          command: yarn test
+  lint:
+    <<: *job_configuration
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v3-dependencies-{{ checksum "package.json" }}
+            - v3-dependencies-
+      - run: yarn install --frozen-lockfile
+      - save_cache:
+          paths:
+            - node_modules
+          key: v3-dependencies-{{ checksum "package.json" }}
+      - run:
+          name: ESLint
+          command: |
+            yarn lint
+      - run:
+          name: Prettier (needed for TS files)
+          command: |
+            yarn prettier --list-different "**/*.js" "**/*.ts"
+workflows:
+  test:
+    jobs:
+      - test
+      - lint


### PR DESCRIPTION
As discussed in https://github.com/satya164/jest-file-snapshot/pull/7#issuecomment-474643950, this adds two CircleCI jobs:
- `test`, which runs `yarn test`
- `lint`, which runs ESLint and Prettier

Note that ESLint doesn't cover `.ts` files (such as `index.d.ts`), which is why Prettier is also run.

See https://circleci.com/gh/fwouts/jest-file-snapshot/tree/circleci for an example run. You should just need to add the project in CircleCI for it to trigger correctly on every branch. I'd also recommend enabling "Build forked pull requests" in the settings, so that checks run automatically on incoming PRs. Make sure to keep "Pass secrets to builds from forked pull requests" off though :)