### PR TITLE
fix: add new `T` type parameter to `Matchers`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare interface FileMatcherOptions {
 
 declare global {
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toMatchFile: (
         output: string,
         filename?: string,


### PR DESCRIPTION
Fixes the error "All declarations of 'Matchers' must have identical type parameters" caused by upgrading to @types/jest 24.0.20. See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/39982